### PR TITLE
Add evaluateTransaction and submitTransaction to Go Contract

### DIFF
--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -20,7 +20,8 @@ import (
 
 // Transaction represents an endorsed transaction that can be submitted to the orderer for commit to the ledger.
 type Transaction struct {
-	contract            *Contract
+	client              gateway.GatewayClient
+	sign                identity.Sign
 	preparedTransaction *gateway.PreparedTransaction
 }
 
@@ -52,7 +53,7 @@ func (transaction *Transaction) Commit() (chan error, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
 
-	stream, err := transaction.contract.network.gateway.client.Commit(ctx, transaction.preparedTransaction)
+	stream, err := transaction.client.Commit(ctx, transaction.preparedTransaction)
 	if err != nil {
 		cancel()
 		return nil, errors.Wrap(err, "Failed to submit transaction to the orderer")
@@ -88,7 +89,7 @@ func (transaction *Transaction) signMessage() error {
 		return err
 	}
 
-	signature, err := transaction.contract.network.gateway.sign(digest)
+	signature, err := transaction.sign(digest)
 	if err != nil {
 		return err
 	}

--- a/scenario/fixtures/crypto-material/core.yaml
+++ b/scenario/fixtures/crypto-material/core.yaml
@@ -549,7 +549,7 @@ chaincode:
     externalBuilders: []
         # - path: /path/to/directory
         #   name: descriptive-builder-name
-        #   environmentWhitelist:
+        #   propagateEnvironment:
         #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
         #      - GOPROXY
 
@@ -588,8 +588,6 @@ chaincode:
         _lifecycle: enable
         cscc: enable
         lscc: enable
-        escc: enable
-        vscc: enable
         qscc: enable
 
     # Logging section for the chaincode container
@@ -678,6 +676,16 @@ ledger:
     # the minimum duration (in milliseconds) between writing
     # two consecutive db batches for converting the ineligible missing data entries to eligible missing data entries
     collElgProcDbBatchesInterval: 1000
+    # The missing data entries are classified into two categories:
+    # (1) prioritized
+    # (2) deprioritized
+    # Initially, all missing data are in the prioritized list. When the
+    # reconciler is unable to fetch the missing data from other peers,
+    # the unreconciled missing data would be moved to the deprioritized list.
+    # The reconciler would retry deprioritized missing data after every
+    # deprioritizedDataReconcilerInterval (unit: minutes). Note that the
+    # interval needs to be greater than the reconcileSleepInterval
+    deprioritizedDataReconcilerInterval: 60m
 
 ###############################################################################
 #

--- a/scenario/go/scenario_test.go
+++ b/scenario/go/scenario_test.go
@@ -410,7 +410,9 @@ func setArguments(argsJSON string) error {
 		return err
 	}
 
-	transaction.options = append(transaction.options, sdk.WithArguments(args...))
+	byteArgs := stringsAsBytes(args)
+	transaction.options = append(transaction.options, sdk.WithArguments(byteArgs...))
+
 	return nil
 }
 
@@ -488,4 +490,14 @@ func jsonEqual(a, b []byte) (bool, error) {
 		return false, err
 	}
 	return reflect.DeepEqual(j2, j), nil
+}
+
+func stringsAsBytes(strings []string) [][]byte {
+	results := make([][]byte, len(strings))
+
+	for i, v := range strings {
+		results[i] = []byte(v)
+	}
+
+	return results
 }


### PR DESCRIPTION
Some refactoring of Go client internals to reduce coupling and make unit testing easier.