### PR TITLE
Signing implementation is optional

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/impl/GatewayImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/impl/GatewayImpl.java
@@ -6,16 +6,14 @@
 
 package org.hyperledger.fabric.client.impl;
 
-import java.io.IOException;
 import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.Gateway;
 import org.hyperledger.fabric.client.Network;
+import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.Signer;
-import org.hyperledger.fabric.client.identity.X509Identity;
 
 public final class GatewayImpl implements Gateway {
     private static final Log LOG = LogFactory.getLog(Gateway.class);
@@ -57,17 +55,13 @@ public final class GatewayImpl implements Gateway {
     private GatewayImpl(final Builder builder) {
         this.url = builder.url;
         this.identity = builder.identity;
-        this.signer = builder.signer;
+        // No signer implementation is required if only offline signing is used
+        this.signer = builder.signer != null ? builder.signer : (byte[] digest) -> {
+            throw new IllegalStateException("No signing implementation supplied");
+        };
 
-        validate();
-    }
-
-    private void validate() {
         if (null == this.identity) {
             throw new IllegalStateException("No client identity supplied");
-        }
-        if (null == this.signer) {
-            throw new IllegalStateException("No signing implementation supplied");
         }
     }
 

--- a/pkg/client/example_gateway_test.go
+++ b/pkg/client/example_gateway_test.go
@@ -23,7 +23,7 @@ func Example() {
 		Port: 1337,
 	}
 
-	gateway, err := client.Connect(id, sign, client.WithEndpoint(endpoint))
+	gateway, err := client.Connect(id, client.WithSign(sign), client.WithEndpoint(endpoint))
 	PanicOnError(err)
 
 	network := gateway.GetNetwork("channelName")

--- a/pkg/client/sign_test.go
+++ b/pkg/client/sign_test.go
@@ -110,4 +110,17 @@ func TestSign(t *testing.T) {
 			t.Fatalf("Expected signature: %v\nGot: %v", expected, actual)
 		}
 	})
+
+	t.Run("Default error implementation is used if nil signing implementation supplied", func(t *testing.T) {
+		mockClient := mock.NewGatewayClient()
+		mockClient.MockEvaluate = func(ctx context.Context, in *gateway.ProposedTransaction, opts ...grpc.CallOption) (*gateway.Result, error) {
+			return &gateway.Result{}, nil
+		}
+
+		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(nil))
+
+		if _, err := contract.EvaluateTransaction("transaction"); nil == err {
+			t.Fatal("Expected signing error but got nil")
+		}
+	})
 }


### PR DESCRIPTION
If then only interaction is transaction invocations using offline signing, it is not necessary to supply a signing implementation on Gateway connect.